### PR TITLE
Fix: Update broken link in README.md to correct cua.py location

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ assert not cache_hit
 
 For a more real example, see a computer-use agent implementation:
 
-[https://github.com/pig-dot-dev/muscle-mem/blob/main/tests/cua.py](https://github.com/pig-dot-dev/muscle-mem/blob/main/tests/cua.py)
+[https://github.com/pig-dot-dev/muscle-mem/blob/main/examples/cua.py](https://github.com/pig-dot-dev/muscle-mem/blob/main/examples/cua.py)
 
 ---
 


### PR DESCRIPTION
The link to the computer-use agent example (cua.py) in the README.md was pointing to `tests/cua.py`, which resulted in a 404 error.

This commit updates the link to point to the correct location of the file at `examples/cua.py`.